### PR TITLE
Using dockerfile to build the image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,9 @@ services:
       - ./fluentd.conf:/fluentd/etc/fluent.conf
       - logs:/opt/logs/:ro
   grok_exporter:
-    image: magentaaps/grok_exporter:latest-rc
+    build:
+      context: .
+      dockerfile: grok-exporter.Dockerfile
     command: -config /opt/grok_exporter.conf
     ports:
       - 9144:9144

--- a/grok_exporter.Dockerfile
+++ b/grok_exporter.Dockerfile
@@ -1,0 +1,58 @@
+# This image has been build to 
+# image: magentaaps/grok_exporter:latest-rc
+#
+# usage instructions:
+# docker build -f grok_exporter.Dockerfile -t magentaaps/grok_exporter:latest-rc .
+#############################
+# Multi-Stage Build
+
+FROM golang:stretch as builder
+ENV GITHUB_REPOSITORY=github.com/fstab/grok_exporter
+
+# Install system deps
+#   We need this in order to build oniguruma.
+#   The debian deb packages for onigurma do not install static libs
+RUN apt-get update && apt-get -y install build-essential make autoconf libtool
+
+# Oniguruma: fetch, build, and install static libs
+RUN cd /tmp && \
+    git clone https://github.com/kkos/oniguruma.git && \
+    cd /tmp/oniguruma && \
+    autoreconf -vfi && \
+    ./configure && \
+    make && \
+    make install
+
+# grok_exporter: fetch source code
+RUN mkdir -p /go/src/$GITHUB_REPOSITORY
+RUN git clone https://$GITHUB_REPOSITORY.git /go/src/$GITHUB_REPOSITORY
+
+# Fetch Golang Dependencies
+WORKDIR /go/src/$GITHUB_REPOSITORY
+RUN git submodule update --init --recursive
+RUN go get
+
+# Build Statically-Linked Binary
+RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build \
+    -ldflags "-w -extldflags \"-static\" \
+    -X ./exporter.Version=$VERSION \
+    -X ./exporter.BuildDate=$(date +%Y-%m-%d) \
+    -X ./exporter.Branch=$(git rev-parse --abbrev-ref HEAD) \
+    -X ./exporter.Revision=$(git rev-parse --short HEAD) \
+    "
+
+RUN cp /go/src/$GITHUB_REPOSITORY/grok_exporter /srv/grok_exporter
+RUN cp -r /go/src/$GITHUB_REPOSITORY/logstash-patterns-core /srv/logstash-patterns-core
+
+#############################
+# Final-Stage Build
+
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /srv/grok_exporter /app/grok_exporter
+COPY --from=builder /srv/logstash-patterns-core /app/logstash-patterns-core
+
+EXPOSE 9144
+ENTRYPOINT [ "/app/grok_exporter" ]


### PR DESCRIPTION
Fixes issue #1 and provides a deterministic way to build the docker image yourself.

All the Dockerfile code was taken directly from https://github.com/magenta-aps/apache_log_exporter/issues/1 

There is one modification: I am now pointing to the main project instead of the magentaaps fork.


NOTE that this image actually now uses the main github repository from github.com/fstab/grok_exporter

Later consideration for the maintainer:

* Make the build more deterministic by locking grok_exporter revision?
* Make the build more deterministic by locking onigurama revision?
* Make the build more deterministic by locking alpine and or debian?

I cannot figure out if there is a risk that the build will break in the future if these are not locked